### PR TITLE
Correctly parse file lines which include negative durations

### DIFF
--- a/lib/m3uzi.rb
+++ b/lib/m3uzi.rb
@@ -325,7 +325,7 @@ protected
   end
 
   def self.parse_file_tag(line)
-    line.match(/^#EXTINF:[ \t]*(\d+),?[ \t]*(.*)$/).values_at(1, 2)
+    line.match(/^#EXTINF:[ \t]*(-?\d+),?[ \t]*(.*)$/).values_at(1, 2)
   end
 
   def self.parse_stream_tag(line)


### PR DESCRIPTION
Many implementations of M3U and PLS will consider a negative length to be "unknown" or "ignore" - this is particularly common with internet streams, but is occasionally seen with actual files, too. The current regex match here will fail when attempting to parse file lines with these negative durations. 

http://forums.winamp.com/showthread.php?threadid=65772

```
m3uzi-451f6d7a767f/lib/m3uzi.rb:329:in `parse_file_tag': undefined method `values_at' for nil:NilClass (NoMethodError)
```

This PR fixes the regex to detect negative durations when present, and parse them correctly. 
